### PR TITLE
Minor improvements to ePlant GeneInfoView panel

### DIFF
--- a/app/scripts/src/Eplant.Views/GeneInfoView/Eplant.Views.GeneInfoView.js
+++ b/app/scripts/src/Eplant.Views/GeneInfoView/Eplant.Views.GeneInfoView.js
@@ -226,12 +226,10 @@
 						},
 						type: "GET",
 						dataType: "json",
-						url: 'https://api.araport.org/community/v0.3/araport/araport11_gff_region_to_jbrowse_v0.1/search?q=features&chr='+this.geneticElement.chromosome.identifier+'&start='+this.chromosome_start+'&end='+this.chromosome_end+'&completely_within=true&interbase=true',
-						//data: { locus: this.geneticElement.identifier },
+						url: 'https://api.araport.org/community/v0.3/araport/araport11_gene_structure_by_locus_v1.1/search?locus='+this.geneticElement.identifier,
 						success: $.proxy(function(data) {
 
 							this.geneModelRawData = JSON.stringify(data);
-							this.geneModelFeatures = data.features;
 							// size settings
 							var margin = 25;
 							var width = 550;
@@ -243,15 +241,20 @@
 								'font-size': '15px'
 							});
 
+							var geneModelFeatures = undefined;
+							for (var i=0;i<data.features.length;i++){
+							  if (data.features[i].uniqueID === this.geneticElement.identifier) {
+							    geneModelFeatures = data.features[i].subfeatures;
+							  }
+							}
 
-							for(var i =0;i<data.features.length;i++){
-								var start = data.features[i].start;
-								var end = data.features[i].end;
+							for(var i =0;i<geneModelFeatures.length;i++){
+								var start = geneModelFeatures[i].start;
+								var end = geneModelFeatures[i].end;
 								var length = Math.abs(end-start);
-								//var subfeatures = data.features[0].subfeatures[0].subfeatures;
-								var subfeatures = data.features[i].subfeatures;
-								var strand = data.features[i].strand;
-								var uniqueID = data.features[i].uniqueID;
+								var subfeatures = geneModelFeatures[i].subfeatures;
+								var strand = geneModelFeatures[i].strand;
+								var uniqueID = geneModelFeatures[i].uniqueID;
 								/* Identifier */
 								var tr = document.createElement("tr");
 								/* Label */
@@ -295,9 +298,9 @@
 										svg.polyline([ [0,height/2], [10,25], [10, 35] ], {fill:'#000000', stroke: 'none'});
 									}
 
-									// sort the subfeatures by type so five_prime_UTR doesn't get overdrawn by exons
+									// sort the subfeatures by type so CDS doesn't get overdrawn by exons/UTRs
 									subfeatures.sort( function(a,b) {
-										return (a.type > b.type) - (a.type < b.type);
+										return -1 * (a.type > b.type) - (b.type > a.type);
 									});
 
 									// draw each GFF
@@ -316,9 +319,8 @@
 										else if (subfeatures[i].type === "CDS") {
 											rec = svg.rect(margin + x, (height/2)-10, w, 20, {fill: '#999999', stroke: 'none', cursor: 'pointer'});
 										}
-
 										else if (subfeatures[i].type === "exon") {
-											rec = svg.rect(margin + x, (height/2)-10, w, 20, {fill: '#999999', stroke: 'none', cursor: 'pointer'});
+											rec = svg.rect(margin + x, (height/2)-10, w, 20, {fill: '#cccccc', stroke: 'none', cursor: 'pointer'});
 										}
 										else if (subfeatures[i].type != "mRNA") {
 											rec = svg.rect(margin + x, (height/2)-2, w, 4, {fill: '#999999', stroke: 'none'});

--- a/app/scripts/src/Eplant.Views/GeneInfoView/Eplant.Views.GeneInfoView.js
+++ b/app/scripts/src/Eplant.Views/GeneInfoView/Eplant.Views.GeneInfoView.js
@@ -174,7 +174,7 @@
 			}
 
 			// Gene Summary information from Araport:
-			$.ajax({
+			var getGeneSummary = $.ajax({
 				beforeSend: function(request) {
 					request.setRequestHeader('Authorization', 'Bearer ' + Agave.token.accessToken);
 				},
@@ -219,9 +219,12 @@
 
 					}
 
+				},this)
+			});
+
 
 					// Get Data For Gene Model
-					$.ajax({
+					var getGeneStructure = $.ajax({
 						beforeSend: function(request) {
 							request.setRequestHeader('Authorization', 'Bearer ' + Agave.token.accessToken);
 						},
@@ -382,18 +385,40 @@
 									}
 								}
 							}
-						},this)
-					});
+							// Only get protein sequence if geneticElementType is 'protein_coding'
+							if (this.geneticElementType === 'protein_coding') {
+								$.ajax({
+									beforeSend: function(request) {
+										request.setRequestHeader('Authorization', 'Bearer ' + Agave.token.accessToken);
+									},
+									type: "GET",
+									dataType: "json",
+									url: 'https://api.araport.org/community/v0.3/aip/get_protein_sequence_by_identifier_v0.2/search?identifier='+this.geneticElement.identifier+'.1',
+									error: $.proxy(function() {
+										$("#"+config.IDs.divProteinSequenceId,this.domContainer).text("The service is not responding, please try again later.");
+										this.loadFail();
+									},this),
+									success: $.proxy(function(summary) {
+										if(summary.result&&summary.result.length>0){
+											this.modelRawData = JSON.stringify(summary);
+											$("#"+config.IDs.divProteinSequenceId,this.domContainer).html(">"+this.geneticElement.identifier+".1"+"<br/>"+summary.result[0].sequence);
+										}
+										else{
+											$("#"+config.IDs.divProteinSequenceId,this.domContainer).text("The service is not responding, please try again later.");
+											this.loadFail();
+										}
 
+									},this)
+								});
+							}
 				},this)
-			});
-
+            });
 
 
 
 
 			// Get DNA sequence
-			$.ajax({
+			var getGenomeSequence = $.ajax({
 				beforeSend: function(request) {
 					request.setRequestHeader('Authorization', 'Bearer ' + Agave.token.accessToken);
 				},
@@ -412,30 +437,6 @@
 						$("#"+config.IDs.divDNAsequenceId,this.domContainer).text("The service is not responding, please try again later.");
 						this.loadFail();
 					}
-				},this)
-			});
-
-			$.ajax({
-				beforeSend: function(request) {
-					request.setRequestHeader('Authorization', 'Bearer ' + Agave.token.accessToken);
-				},
-				type: "GET",
-				dataType: "json",
-				url: 'https://api.araport.org/community/v0.3/aip/get_protein_sequence_by_identifier_v0.2/search?identifier='+this.geneticElement.identifier+'.1',
-				error: $.proxy(function() {
-					$("#"+config.IDs.divProteinSequenceId,this.domContainer).text("The service is not responding, please try again later.");
-					this.loadFail();
-				},this),
-				success: $.proxy(function(summary) {
-					if(summary.result&&summary.result.length>0){
-						this.modelRawData = JSON.stringify(summary);
-						$("#"+config.IDs.divProteinSequenceId,this.domContainer).html(">"+this.geneticElement.identifier+".1"+"<br/>"+summary.result[0].sequence);
-					}
-					else{
-						$("#"+config.IDs.divProteinSequenceId,this.domContainer).text("The service is not responding, please try again later.");
-						this.loadFail();
-					}
-
 				},this)
 			});
 


### PR DESCRIPTION
Hi @asherpasha, @jamiewaese, @nprovart -

In this PR, you should find the following changes:

1. **Updates to the adapter used to fetch gene structure information**: Previously you were using "araport11_gff_region_to_jbrowse" (which relied on an indexed GFF3 file to generate the JSON data). I've now switched to use "araport11_gene_structure_by_locus_v0.1" which takes as input an AGI locus identifier, and returns JSON data directly from ThaleMine (using the InterMine JBrowse REST API).

2. **Updates to the gene structure rendering**:
- Since the JSON data contains UTRs, exons and CDS feature types as subfeatures of an mRNA, we can skip the rendering of exons, and only show the UTR + CDS features (since UTRs are exons minus CDS).
- I've added a minor tweak to the rendering of the UTR, by reducing the height of the glyph so that it looks distinct from the CDS glyph. Here is an example (for ABI3):
![image](https://cloud.githubusercontent.com/assets/711637/21737050/8776442c-d443-11e6-82f1-e2dc0f97af2f.png)

3. **Only render the protein sequence panel if the entity requested in ePlant is of type "protein-coding"**. This is done by inspecting the JSON data object and identifying the feature type. Once identified, this information is used to conditionally invoke the protein sequence API. By doing this, we can ensure that the GeneInfoView panel loads properly for non protein-coding feature types, for example: AT1G01448 (type: antisense_lncRNA)

Please review these changes and accept if you find them suitable. I've deployed the app to araport.org for testing (please see: https://www.araport.org/apps/vivek/araport-eplant)

Thank you!

Regards,
Vivek

cc @eriksf @mwvaughn @agnespychan @cdtown